### PR TITLE
[HACK] selftests/bpf: Increase signal waiting time in send_signal

### DIFF
--- a/tools/testing/selftests/bpf/prog_tests/send_signal.c
+++ b/tools/testing/selftests/bpf/prog_tests/send_signal.c
@@ -64,7 +64,7 @@ static void test_send_signal_common(struct perf_event_attr *attr,
 		ASSERT_EQ(read(pipe_p2c[0], buf, 1), 1, "pipe_read");
 
 		/* wait a little for signal handler */
-		for (int i = 0; i < 1000000000 && !sigusr1_received; i++) {
+		for (int i = 0; i < 2000000000 && !sigusr1_received; i++) {
 			j /= i + j + 1;
 			if (!attr)
 				/* trigger the nanosleep tracepoint program. */


### PR DESCRIPTION
Increase signal waiting time from one second to two seconds in order to increase chance that signal can be delivered.