### PR TITLE
Add DENYLIST for RC tier

### DIFF
--- a/ci/vmtest/configs/DENYLIST.rc
+++ b/ci/vmtest/configs/DENYLIST.rc
@@ -1,0 +1,3 @@
+send_signal/send_signal_nmi            # PMU events configure correctly but don't trigger NMI's for some reason (AMD nested virt)
+send_signal/send_signal_nmi_thread     # Same as above
+token/obj_priv_implicit_token_envvar   # Unknown root cause, but reliably fails

--- a/ci/vmtest/vmtest_selftests.sh
+++ b/ci/vmtest/vmtest_selftests.sh
@@ -13,6 +13,7 @@ set -euo pipefail
 source "$(cd "$(dirname "$0")" && pwd)/helpers.sh"
 
 ARCH=$(uname -m)
+DEPLOYMENT=$(if [[ "$GITHUB_REPOSITORY" == *"-rc" ]]; then echo "rc"; else echo "prod"; fi)
 
 STATUS_FILE=/mnt/vmtest/exitstatus
 OUTPUT_DIR=/mnt/vmtest
@@ -34,6 +35,7 @@ DENYLIST=$(read_lists \
 	"$BPF_SELFTESTS_DIR/DENYLIST.${ARCH}" \
 	"$VMTEST_CONFIGS_PATH/DENYLIST" \
 	"$VMTEST_CONFIGS_PATH/DENYLIST.${ARCH}" \
+	"$VMTEST_CONFIGS_PATH/DENYLIST.${DEPLOYMENT}" \
 )
 ALLOWLIST=$(read_lists \
 	"$BPF_SELFTESTS_DIR/ALLOWLIST" \


### PR DESCRIPTION
Production CI runs on bare-metal self hosted runners. RC CI runs on nested virt GH hosted runners. The difference in platform causes issues with some selftests. So add a DENYLIST to skip tests that are too difficult to debug.