### PR TITLE
[ai review test] bpf: Allow bpf_tcp_sock() helper in XDP

### DIFF
--- a/net/core/filter.c
+++ b/net/core/filter.c
@@ -8506,6 +8506,8 @@ xdp_func_proto(enum bpf_func_id func_id, const struct bpf_prog *prog)
 		return &bpf_sk_release_proto;
 	case BPF_FUNC_skc_lookup_tcp:
 		return &bpf_xdp_skc_lookup_tcp_proto;
+	case BPF_FUNC_tcp_sock:
+		return &bpf_tcp_sock_proto;
 	case BPF_FUNC_tcp_check_syncookie:
 		return &bpf_tcp_check_syncookie_proto;
 	case BPF_FUNC_tcp_gen_syncookie:


### PR DESCRIPTION
We can already lookup sockets in XDP via the bpf_sk(c)_lookup_(udp|tcp) helpers. This can be used to determine if a received packet is for an established socket or not, for example in a load balancer.

But the TCP TIME-WAIT state needs special handling for this: packets received for a TIME-WAIT socket can either belong to the current incarnation of the connection, or a new incarnation. The only way to determine this is to compare the sequence numbers.

Add the bpf_tcp_sock() helper in XDP to allow the socket sequence numbers to be read.